### PR TITLE
Added number support to regex

### DIFF
--- a/jscripts/automention/automention.js
+++ b/jscripts/automention/automention.js
@@ -8,7 +8,7 @@ var ment_settings = {
 	callbacks: {
 		matcher: function(flag, subtext) {
 			var match, matched, regexp;
-			regexp = new XRegExp('(\\s+|^)' + flag + '(\\p{L}+)$', 'gi');
+			regexp = new XRegExp('(\\s+|^)' + flag + '([\\p{L}|\\p{N}]+)$', 'gi');
 			match = regexp.exec(subtext);
 			if (match) {
 				matched = match[2];
@@ -19,7 +19,7 @@ var ment_settings = {
 			if (query.length > 2) {
 				$.getJSON('xmlhttp.php?action=get_users', {query: query}, function(data) {
 					callback(data);
-				});			
+				});
 			}
 			else {
 				callback([]);


### PR DESCRIPTION
Added number support to usernames in regex. Users with numbers in the first three characters of their name were impossible to search for and results disappeared as soon as you reached a number in a persons name.
